### PR TITLE
Add `is` keyword to roc syntax

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -232,7 +232,7 @@
 				},
 				{
 					"name": "keyword.fsharp",
-					"match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
+					"match": "\\b(private|to|public|internal|function|yield!|yield|class|exception|match|delegate|of|new|in|as|if|then|else|elif|for|begin|end|inherit|do|let\\!|return\\!|return|interface|with|abstract|enum|member|try|finally|and|when|is|or|use|use\\!|struct|while|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
 				},
 				{
 					"name": "keyword.fsharp",
@@ -307,7 +307,7 @@
 					]
 				},
 				{
-					"match": "(?!when|and|or\\b)\\b([\\w0-9'`^._]+)",
+					"match": "(?!when|is|and|or\\b)\\b([\\w0-9'`^._]+)",
 					"comments": "Here we need the \\w modifier in order to check that the words isn't blacklisted",
 					"captures": {
 						"1": {
@@ -702,7 +702,7 @@
 					"patterns": [
 						{
 							"name": "keyword.fsharp",
-							"match": "\\b(and|when|or)\\b"
+							"match": "\\b(and|when|is|or)\\b"
 						},
 						{
 							"comment": "Because we first capture the keywords, we can capture what looks like a word and assume it's an entity definition",
@@ -1031,7 +1031,7 @@
 				},
 				{
 					"name": "keyword.fsharp",
-					"match": "\\b(private|to|public|internal|function|class|exception|delegate|of|as|begin|end|inherit|let!|interface|abstract|enum|member|and|when|or|use|use\\!|struct|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
+					"match": "\\b(private|to|public|internal|function|class|exception|delegate|of|as|begin|end|inherit|let!|interface|abstract|enum|member|and|when|is|or|use|use\\!|struct|mutable|assert|base|done|downcast|downto|extern|fixed|global|lazy|upcast|not)(?!')\\b"
 				},
 				{
 					"name": "keyword.control",


### PR DESCRIPTION
This adds highlighting for the `is` keyword in pattern matches:

<img width="130" alt="image" src="https://user-images.githubusercontent.com/17142/215568015-1cd0440c-e35e-4e41-8491-ede5b42da087.png">
